### PR TITLE
Tutorial : A Documented Pull Request

### DIFF
--- a/code/docker-compose.yaml
+++ b/code/docker-compose.yaml
@@ -1,0 +1,12 @@
+version: "3.8"
+services:
+  db:
+    image: mysql
+    ports:
+      - "3306:3306"
+    environment:
+      - MYSQL_ALLOW_EMPTY_PASSWORD=true
+  etherpad:
+    image: etherpad/etherpad
+    ports:
+      - "9001:9001"


### PR DESCRIPTION
# Make the Doodlestudent project works!

## Running docker-compose

The very first thing I have to do is to launch services that the application depends on.
To do so, I have to run the `docker-compose.yaml` 

However, a first error comes when running command `sudo docker-compose up`, the docker-compose version does not accept the `3.8`
```sh
ERROR: Version "3.8" in "./docker-compose.yaml" is invalid.
```

After searching in the docs, the `3.8` version need the docker-compose at version <=1.25.5 which is available for the versions of docker <= 19.03.0 

From this point, the dependencies start with no problem.

## Starting the application

Because I experimented with multiple application startups, I found out that the application starts by creating the database without checking the existence of a previous database. The fact is that it creates errors when starting the application a second time.

![second-startup](https://user-images.githubusercontent.com/68585341/100284384-65291a80-2f6f-11eb-99f7-7437798c5a58.png)

The fix is quite simple: stop the containers after the application close and restart them before the launch.
In other terms : 
```sh
# Start the app
sudo docker-compose up --detach & ./mvnw compile quarkus:dev

# Ctrl+C to stop and then :
sudo docker-compose down
```

## Play with the application

After trying to use the app, I was blocked in the creation of a poll.
The scenario is the following : 

- I start the dependencies and the application
- I fill the title, place and description of the event
- I select some dates
- And ... it's blocked

The error was an authentication error saying that the wrong API key was used.
I started the docker container of etherpad alone and looked at the logs.
The logs indicated that the `APIKEY.txt` file which contains the API key was not found, hence generated randomly.

![random-key](https://user-images.githubusercontent.com/68585341/100284383-64908400-2f6f-11eb-84cc-b9295fd7f3b1.png)
 
To patch the problem, I asked the generated file, set it in the project and updated the `docker-compose.yaml`