### PR TITLE
[Raclette] Tutorial : Software bots in Software Engineering

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "maven" # See documentation for possible values
+    directory: "/api" # Location of package manifests
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
# Installing the DoodleStudent Project

We started the installation of the Doodle project on Windows and Linux.
When we tried it on Linux we encountered several problems which we will explain later, but we finally decided to run it on Windows. 

We run the project in two different ways : 
The first computer could use docker compose and thus could launch the api application in development mode.
The second one uses maven jar packaging in order to start the application.
